### PR TITLE
Organize http presets by code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ throw new ErrorX({
 })
 
 // Using HTTP presets
-throw new ErrorX(http.notFound)
+throw new ErrorX(http[404])
 
 // Customizing presets
 throw new ErrorX({
-  ...http.unauthorized,
+  ...http[401],
   message: 'Session expired',
   metadata: { userId: 123 }
 })
@@ -115,12 +115,12 @@ ErrorX provides pre-configured error templates via the `http` export:
 import { ErrorX, http } from '@bombillazo/error-x'
 
 // Use preset directly
-throw new ErrorX(http.notFound)
+throw new ErrorX(http[404])
 // Result: 404 error with message "Not found.", code "NOT_FOUND", etc.
 
 // Override specific fields
 throw new ErrorX({
-  ...http.notFound,
+  ...http[404],
   message: 'User not found',
   metadata: { userId: 123 }
 })
@@ -130,7 +130,7 @@ try {
   // some operation
 } catch (originalError) {
   throw new ErrorX({
-    ...http.internalServerError,
+    ...http[500],
     cause: originalError,
     metadata: { operation: 'database-query' }
   })
@@ -139,7 +139,7 @@ try {
 
 #### Available Presets
 
-All presets use **camelCase naming** and include:
+All presets are indexed by **HTTP status code** (numeric keys) and include:
 - `httpStatus`: HTTP status code
 - `code`: Error code in UPPER_SNAKE_CASE
 - `name`: Descriptive error name
@@ -149,10 +149,10 @@ All presets use **camelCase naming** and include:
 
 **4xx Client Errors:**
 
-`badRequest`, `unauthorized`, `paymentRequired`, `forbidden`, `notFound`, `methodNotAllowed`, `notAcceptable`, `proxyAuthenticationRequired`, `requestTimeout`, `conflict`, `gone`, `lengthRequired`, `preconditionFailed`, `payloadTooLarge`, `uriTooLong`, `unsupportedMediaType`, `rangeNotSatisfiable`, `expectationFailed`, `imATeapot`, `unprocessableEntity`, `locked`, `failedDependency`, `tooEarly`, `upgradeRequired`, `preconditionRequired`, `tooManyRequests`, `requestHeaderFieldsTooLarge`, `unavailableForLegalReasons`
+`400`, `401`, `402`, `403`, `404`, `405`, `406`, `407`, `408`, `409`, `410`, `411`, `412`, `413`, `414`, `415`, `416`, `417`, `418`, `422`, `423`, `424`, `425`, `426`, `428`, `429`, `431`, `451`
 
 **5xx Server Errors:**
-`internalServerError`, `notImplemented`, `badGateway`, `serviceUnavailable`, `gatewayTimeout`, `httpVersionNotSupported`, `variantAlsoNegotiates`, `insufficientStorage`, `loopDetected`, `notExtended`, `networkAuthenticationRequired`
+`500`, `501`, `502`, `503`, `504`, `505`, `506`, `507`, `508`, `510`, `511`
 
 #### Creating Your Own Presets
 
@@ -344,7 +344,7 @@ async function fetchUser(id: string) {
     const response = await fetch(`/api/users/${id}`)
     if (!response.ok) {
       throw new ErrorX({
-        ...http[response.status === 404 ? 'notFound' : 'internalServerError'],
+        ...http[response.status === 404 ? 404 : 500],
         metadata: { status: response.status, statusText: response.statusText }
       })
     }

--- a/docs/api/error-x.http.md
+++ b/docs/api/error-x.http.md
@@ -13,14 +13,14 @@ These presets provide pre-configured error options for standard HTTP error respo
 \#\#\# 1. Use Preset Directly Create an error with all preset values:
 
 ```typescript
-throw new ErrorX(http.notFound)
+throw new ErrorX(http[404])
 // Result: 404 error with message "Not found.", code, name, uiMessage, and type
 ```
 \#\#\# 2. Override Specific Fields Customize the error while keeping other preset values:
 
 ```typescript
 throw new ErrorX({
-  ...http.notFound,
+  ...http[404],
   message: 'User not found',
   metadata: { userId: 123 }
 })
@@ -30,7 +30,7 @@ throw new ErrorX({
 
 ```typescript
 throw new ErrorX({
-  ...http.unauthorized,
+  ...http[401],
   metadata: { attemptedAction: 'viewProfile', userId: 456 }
 })
 ```
@@ -41,7 +41,7 @@ try {
   // some operation
 } catch (originalError) {
   throw new ErrorX({
-    ...http.internalServerError,
+    ...http[500],
     cause: originalError,
     metadata: { operation: 'database-query' }
   })
@@ -49,15 +49,15 @@ try {
 ```
 \#\# Common HTTP Presets
 
-\#\#\# 4xx Client Errors - `badRequest` (400) - Invalid request data - `unauthorized` (401) - Authentication required - `forbidden` (403) - Insufficient permissions - `notFound` (404) - Resource not found - `methodNotAllowed` (405) - HTTP method not allowed - `conflict` (409) - Resource conflict - `unprocessableEntity` (422) - Validation failed - `tooManyRequests` (429) - Rate limit exceeded
+\#\#\# 4xx Client Errors - `400` - Bad Request - Invalid request data - `401` - Unauthorized - Authentication required - `403` - Forbidden - Insufficient permissions - `404` - Not Found - Resource not found - `405` - Method Not Allowed - HTTP method not allowed - `409` - Conflict - Resource conflict - `422` - Unprocessable Entity - Validation failed - `429` - Too Many Requests - Rate limit exceeded
 
-\#\#\# 5xx Server Errors - `internalServerError` (500) - Unexpected server error - `notImplemented` (501) - Feature not implemented - `badGateway` (502) - Upstream server error - `serviceUnavailable` (503) - Service temporarily down - `gatewayTimeout` (504) - Upstream timeout
+\#\#\# 5xx Server Errors - `500` - Internal Server Error - Unexpected server error - `501` - Not Implemented - Feature not implemented - `502` - Bad Gateway - Upstream server error - `503` - Service Unavailable - Service temporarily down - `504` - Gateway Timeout - Upstream timeout
 
 **Signature:**
 
 ```typescript
 http: {
-    readonly badRequest: {
+    readonly 400: {
         httpStatus: number;
         code: string;
         name: string;
@@ -65,7 +65,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly unauthorized: {
+    readonly 401: {
         httpStatus: number;
         code: string;
         name: string;
@@ -73,7 +73,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly paymentRequired: {
+    readonly 402: {
         httpStatus: number;
         code: string;
         name: string;
@@ -81,7 +81,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly forbidden: {
+    readonly 403: {
         httpStatus: number;
         code: string;
         name: string;
@@ -89,7 +89,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly notFound: {
+    readonly 404: {
         httpStatus: number;
         code: string;
         name: string;
@@ -97,7 +97,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly methodNotAllowed: {
+    readonly 405: {
         httpStatus: number;
         code: string;
         name: string;
@@ -105,7 +105,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly notAcceptable: {
+    readonly 406: {
         httpStatus: number;
         code: string;
         name: string;
@@ -113,7 +113,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly proxyAuthenticationRequired: {
+    readonly 407: {
         httpStatus: number;
         code: string;
         name: string;
@@ -121,7 +121,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly requestTimeout: {
+    readonly 408: {
         httpStatus: number;
         code: string;
         name: string;
@@ -129,7 +129,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly conflict: {
+    readonly 409: {
         httpStatus: number;
         code: string;
         name: string;
@@ -137,7 +137,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly gone: {
+    readonly 410: {
         httpStatus: number;
         code: string;
         name: string;
@@ -145,7 +145,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly lengthRequired: {
+    readonly 411: {
         httpStatus: number;
         code: string;
         name: string;
@@ -153,7 +153,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly preconditionFailed: {
+    readonly 412: {
         httpStatus: number;
         code: string;
         name: string;
@@ -161,7 +161,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly payloadTooLarge: {
+    readonly 413: {
         httpStatus: number;
         code: string;
         name: string;
@@ -169,7 +169,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly uriTooLong: {
+    readonly 414: {
         httpStatus: number;
         code: string;
         name: string;
@@ -177,7 +177,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly unsupportedMediaType: {
+    readonly 415: {
         httpStatus: number;
         code: string;
         name: string;
@@ -185,7 +185,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly rangeNotSatisfiable: {
+    readonly 416: {
         httpStatus: number;
         code: string;
         name: string;
@@ -193,7 +193,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly expectationFailed: {
+    readonly 417: {
         httpStatus: number;
         code: string;
         name: string;
@@ -201,7 +201,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly imATeapot: {
+    readonly 418: {
         httpStatus: number;
         code: string;
         name: string;
@@ -209,7 +209,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly unprocessableEntity: {
+    readonly 422: {
         httpStatus: number;
         code: string;
         name: string;
@@ -217,7 +217,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly locked: {
+    readonly 423: {
         httpStatus: number;
         code: string;
         name: string;
@@ -225,7 +225,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly failedDependency: {
+    readonly 424: {
         httpStatus: number;
         code: string;
         name: string;
@@ -233,7 +233,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly tooEarly: {
+    readonly 425: {
         httpStatus: number;
         code: string;
         name: string;
@@ -241,7 +241,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly upgradeRequired: {
+    readonly 426: {
         httpStatus: number;
         code: string;
         name: string;
@@ -249,7 +249,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly preconditionRequired: {
+    readonly 428: {
         httpStatus: number;
         code: string;
         name: string;
@@ -257,7 +257,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly tooManyRequests: {
+    readonly 429: {
         httpStatus: number;
         code: string;
         name: string;
@@ -265,7 +265,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly requestHeaderFieldsTooLarge: {
+    readonly 431: {
         httpStatus: number;
         code: string;
         name: string;
@@ -273,7 +273,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly unavailableForLegalReasons: {
+    readonly 451: {
         httpStatus: number;
         code: string;
         name: string;
@@ -281,7 +281,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly internalServerError: {
+    readonly 500: {
         httpStatus: number;
         code: string;
         name: string;
@@ -289,7 +289,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly notImplemented: {
+    readonly 501: {
         httpStatus: number;
         code: string;
         name: string;
@@ -297,7 +297,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly badGateway: {
+    readonly 502: {
         httpStatus: number;
         code: string;
         name: string;
@@ -305,7 +305,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly serviceUnavailable: {
+    readonly 503: {
         httpStatus: number;
         code: string;
         name: string;
@@ -313,7 +313,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly gatewayTimeout: {
+    readonly 504: {
         httpStatus: number;
         code: string;
         name: string;
@@ -321,7 +321,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly httpVersionNotSupported: {
+    readonly 505: {
         httpStatus: number;
         code: string;
         name: string;
@@ -329,7 +329,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly variantAlsoNegotiates: {
+    readonly 506: {
         httpStatus: number;
         code: string;
         name: string;
@@ -337,7 +337,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly insufficientStorage: {
+    readonly 507: {
         httpStatus: number;
         code: string;
         name: string;
@@ -345,7 +345,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly loopDetected: {
+    readonly 508: {
         httpStatus: number;
         code: string;
         name: string;
@@ -353,7 +353,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly notExtended: {
+    readonly 510: {
         httpStatus: number;
         code: string;
         name: string;
@@ -361,7 +361,7 @@ http: {
         uiMessage: string;
         type: string;
     };
-    readonly networkAuthenticationRequired: {
+    readonly 511: {
         httpStatus: number;
         code: string;
         name: string;
@@ -382,7 +382,7 @@ app.get('/users/:id', async (req, res) => {
 
   if (!user) {
     throw new ErrorX({
-      ...http.notFound,
+      ...http[404],
       message: 'User not found',
       metadata: { userId: req.params.id }
     })
@@ -394,7 +394,7 @@ app.get('/users/:id', async (req, res) => {
 // Authentication middleware example
 const requireAuth = (req, res, next) => {
   if (!req.user) {
-    throw new ErrorX(http.unauthorized)
+    throw new ErrorX(http[401])
   }
   next()
 }
@@ -402,7 +402,7 @@ const requireAuth = (req, res, next) => {
 // Rate limiting example
 if (isRateLimited(req.ip)) {
   throw new ErrorX({
-    ...http.tooManyRequests,
+    ...http[429],
     metadata: {
       ip: req.ip,
       retryAfter: 60

--- a/docs/api/error-x.md
+++ b/docs/api/error-x.md
@@ -85,14 +85,14 @@ These presets provide pre-configured error options for standard HTTP error respo
 \#\#\# 1. Use Preset Directly Create an error with all preset values:
 
 ```typescript
-throw new ErrorX(http.notFound)
+throw new ErrorX(http[404])
 // Result: 404 error with message "Not found.", code, name, uiMessage, and type
 ```
 \#\#\# 2. Override Specific Fields Customize the error while keeping other preset values:
 
 ```typescript
 throw new ErrorX({
-  ...http.notFound,
+  ...http[404],
   message: 'User not found',
   metadata: { userId: 123 }
 })
@@ -102,7 +102,7 @@ throw new ErrorX({
 
 ```typescript
 throw new ErrorX({
-  ...http.unauthorized,
+  ...http[401],
   metadata: { attemptedAction: 'viewProfile', userId: 456 }
 })
 ```
@@ -113,7 +113,7 @@ try {
   // some operation
 } catch (originalError) {
   throw new ErrorX({
-    ...http.internalServerError,
+    ...http[500],
     cause: originalError,
     metadata: { operation: 'database-query' }
   })
@@ -121,9 +121,9 @@ try {
 ```
 \#\# Common HTTP Presets
 
-\#\#\# 4xx Client Errors - `badRequest` (400) - Invalid request data - `unauthorized` (401) - Authentication required - `forbidden` (403) - Insufficient permissions - `notFound` (404) - Resource not found - `methodNotAllowed` (405) - HTTP method not allowed - `conflict` (409) - Resource conflict - `unprocessableEntity` (422) - Validation failed - `tooManyRequests` (429) - Rate limit exceeded
+\#\#\# 4xx Client Errors - `400` - Bad Request - Invalid request data - `401` - Unauthorized - Authentication required - `403` - Forbidden - Insufficient permissions - `404` - Not Found - Resource not found - `405` - Method Not Allowed - HTTP method not allowed - `409` - Conflict - Resource conflict - `422` - Unprocessable Entity - Validation failed - `429` - Too Many Requests - Rate limit exceeded
 
-\#\#\# 5xx Server Errors - `internalServerError` (500) - Unexpected server error - `notImplemented` (501) - Feature not implemented - `badGateway` (502) - Upstream server error - `serviceUnavailable` (503) - Service temporarily down - `gatewayTimeout` (504) - Upstream timeout
+\#\#\# 5xx Server Errors - `500` - Internal Server Error - Unexpected server error - `501` - Not Implemented - Feature not implemented - `502` - Bad Gateway - Upstream server error - `503` - Service Unavailable - Service temporarily down - `504` - Gateway Timeout - Upstream timeout
 
 
 </td></tr>

--- a/src/__tests__/presets.test.ts
+++ b/src/__tests__/presets.test.ts
@@ -3,8 +3,8 @@ import { ErrorX, http } from '../index.js';
 
 describe('HTTP Presets', () => {
   describe('Basic preset usage', () => {
-    it('should create error with notFound preset', () => {
-      const error = new ErrorX(http.notFound);
+    it('should create error with 404 preset', () => {
+      const error = new ErrorX(http[404]);
 
       expect(error.httpStatus).toBe(404);
       expect(error.code).toBe('NOT_FOUND');
@@ -15,8 +15,8 @@ describe('HTTP Presets', () => {
       expect(error).toBeInstanceOf(ErrorX);
     });
 
-    it('should create error with unauthorized preset', () => {
-      const error = new ErrorX(http.unauthorized);
+    it('should create error with 401 preset', () => {
+      const error = new ErrorX(http[401]);
 
       expect(error.httpStatus).toBe(401);
       expect(error.code).toBe('UNAUTHORIZED');
@@ -26,8 +26,8 @@ describe('HTTP Presets', () => {
       expect(error.type).toBe('http');
     });
 
-    it('should create error with internalServerError preset', () => {
-      const error = new ErrorX(http.internalServerError);
+    it('should create error with 500 preset', () => {
+      const error = new ErrorX(http[500]);
 
       expect(error.httpStatus).toBe(500);
       expect(error.code).toBe('INTERNAL_SERVER_ERROR');
@@ -41,7 +41,7 @@ describe('HTTP Presets', () => {
   describe('Preset override', () => {
     it('should override preset message', () => {
       const error = new ErrorX({
-        ...http.notFound,
+        ...http[404],
         message: 'User not found',
       });
 
@@ -53,7 +53,7 @@ describe('HTTP Presets', () => {
 
     it('should override preset code', () => {
       const error = new ErrorX({
-        ...http.badRequest,
+        ...http[400],
         code: 'VALIDATION_ERROR',
       });
 
@@ -64,7 +64,7 @@ describe('HTTP Presets', () => {
 
     it('should override preset name', () => {
       const error = new ErrorX({
-        ...http.forbidden,
+        ...http[403],
         name: 'AccessDeniedError',
       });
 
@@ -75,7 +75,7 @@ describe('HTTP Presets', () => {
 
     it('should override multiple preset values', () => {
       const error = new ErrorX({
-        ...http.notFound,
+        ...http[404],
         message: 'Product not found',
         code: 'PRODUCT_NOT_FOUND',
         name: 'ProductNotFoundError',
@@ -91,7 +91,7 @@ describe('HTTP Presets', () => {
   describe('Preset with additional options', () => {
     it('should add metadata to preset', () => {
       const error = new ErrorX({
-        ...http.notFound,
+        ...http[404],
         metadata: { userId: 123, resource: 'user' },
       });
 
@@ -101,7 +101,7 @@ describe('HTTP Presets', () => {
 
     it('should override uiMessage from preset', () => {
       const error = new ErrorX({
-        ...http.unauthorized,
+        ...http[401],
         uiMessage: 'Custom message: Please log in',
       });
 
@@ -112,7 +112,7 @@ describe('HTTP Presets', () => {
     it('should add cause to preset', () => {
       const originalError = new Error('Database connection failed');
       const error = new ErrorX({
-        ...http.internalServerError,
+        ...http[500],
         cause: originalError,
       });
 
@@ -127,29 +127,29 @@ describe('HTTP Presets', () => {
 
   describe('Common HTTP status codes', () => {
     it('should have correct 4xx client error presets', () => {
-      expect(http.badRequest.httpStatus).toBe(400);
-      expect(http.unauthorized.httpStatus).toBe(401);
-      expect(http.forbidden.httpStatus).toBe(403);
-      expect(http.notFound.httpStatus).toBe(404);
-      expect(http.methodNotAllowed.httpStatus).toBe(405);
-      expect(http.conflict.httpStatus).toBe(409);
-      expect(http.unprocessableEntity.httpStatus).toBe(422);
-      expect(http.tooManyRequests.httpStatus).toBe(429);
+      expect(http[400].httpStatus).toBe(400);
+      expect(http[401].httpStatus).toBe(401);
+      expect(http[403].httpStatus).toBe(403);
+      expect(http[404].httpStatus).toBe(404);
+      expect(http[405].httpStatus).toBe(405);
+      expect(http[409].httpStatus).toBe(409);
+      expect(http[422].httpStatus).toBe(422);
+      expect(http[429].httpStatus).toBe(429);
     });
 
     it('should have correct 5xx server error presets', () => {
-      expect(http.internalServerError.httpStatus).toBe(500);
-      expect(http.notImplemented.httpStatus).toBe(501);
-      expect(http.badGateway.httpStatus).toBe(502);
-      expect(http.serviceUnavailable.httpStatus).toBe(503);
-      expect(http.gatewayTimeout.httpStatus).toBe(504);
+      expect(http[500].httpStatus).toBe(500);
+      expect(http[501].httpStatus).toBe(501);
+      expect(http[502].httpStatus).toBe(502);
+      expect(http[503].httpStatus).toBe(503);
+      expect(http[504].httpStatus).toBe(504);
     });
   });
 
   describe('Serialization', () => {
     it('should serialize preset-based error', () => {
       const error = new ErrorX({
-        ...http.notFound,
+        ...http[404],
         metadata: { userId: 123 },
       });
 
@@ -189,7 +189,7 @@ describe('HTTP Presets', () => {
   describe('Type safety', () => {
     it('should maintain proper types when spreading presets', () => {
       const options = {
-        ...http.badRequest,
+        ...http[400],
         metadata: { field: 'email' },
       };
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -11,7 +11,7 @@ import type { ErrorXOptions } from './types.js';
  * ### 1. Use Preset Directly
  * Create an error with all preset values:
  * ```typescript
- * throw new ErrorX(http.notFound)
+ * throw new ErrorX(http[404])
  * // Result: 404 error with message "Not found.", code, name, uiMessage, and type
  * ```
  *
@@ -19,7 +19,7 @@ import type { ErrorXOptions } from './types.js';
  * Customize the error while keeping other preset values:
  * ```typescript
  * throw new ErrorX({
- *   ...http.notFound,
+ *   ...http[404],
  *   message: 'User not found',
  *   metadata: { userId: 123 }
  * })
@@ -30,7 +30,7 @@ import type { ErrorXOptions } from './types.js';
  * Enhance presets with additional context:
  * ```typescript
  * throw new ErrorX({
- *   ...http.unauthorized,
+ *   ...http[401],
  *   metadata: { attemptedAction: 'viewProfile', userId: 456 }
  * })
  * ```
@@ -42,7 +42,7 @@ import type { ErrorXOptions } from './types.js';
  *   // some operation
  * } catch (originalError) {
  *   throw new ErrorX({
- *     ...http.internalServerError,
+ *     ...http[500],
  *     cause: originalError,
  *     metadata: { operation: 'database-query' }
  *   })
@@ -52,21 +52,21 @@ import type { ErrorXOptions } from './types.js';
  * ## Common HTTP Presets
  *
  * ### 4xx Client Errors
- * - `badRequest` (400) - Invalid request data
- * - `unauthorized` (401) - Authentication required
- * - `forbidden` (403) - Insufficient permissions
- * - `notFound` (404) - Resource not found
- * - `methodNotAllowed` (405) - HTTP method not allowed
- * - `conflict` (409) - Resource conflict
- * - `unprocessableEntity` (422) - Validation failed
- * - `tooManyRequests` (429) - Rate limit exceeded
+ * - `400` - Bad Request - Invalid request data
+ * - `401` - Unauthorized - Authentication required
+ * - `403` - Forbidden - Insufficient permissions
+ * - `404` - Not Found - Resource not found
+ * - `405` - Method Not Allowed - HTTP method not allowed
+ * - `409` - Conflict - Resource conflict
+ * - `422` - Unprocessable Entity - Validation failed
+ * - `429` - Too Many Requests - Rate limit exceeded
  *
  * ### 5xx Server Errors
- * - `internalServerError` (500) - Unexpected server error
- * - `notImplemented` (501) - Feature not implemented
- * - `badGateway` (502) - Upstream server error
- * - `serviceUnavailable` (503) - Service temporarily down
- * - `gatewayTimeout` (504) - Upstream timeout
+ * - `500` - Internal Server Error - Unexpected server error
+ * - `501` - Not Implemented - Feature not implemented
+ * - `502` - Bad Gateway - Upstream server error
+ * - `503` - Service Unavailable - Service temporarily down
+ * - `504` - Gateway Timeout - Upstream timeout
  *
  * @example
  * ```typescript
@@ -76,7 +76,7 @@ import type { ErrorXOptions } from './types.js';
  *
  *   if (!user) {
  *     throw new ErrorX({
- *       ...http.notFound,
+ *       ...http[404],
  *       message: 'User not found',
  *       metadata: { userId: req.params.id }
  *     })
@@ -88,7 +88,7 @@ import type { ErrorXOptions } from './types.js';
  * // Authentication middleware example
  * const requireAuth = (req, res, next) => {
  *   if (!req.user) {
- *     throw new ErrorX(http.unauthorized)
+ *     throw new ErrorX(http[401])
  *   }
  *   next()
  * }
@@ -96,7 +96,7 @@ import type { ErrorXOptions } from './types.js';
  * // Rate limiting example
  * if (isRateLimited(req.ip)) {
  *   throw new ErrorX({
- *     ...http.tooManyRequests,
+ *     ...http[429],
  *     metadata: {
  *       ip: req.ip,
  *       retryAfter: 60
@@ -109,7 +109,7 @@ import type { ErrorXOptions } from './types.js';
  */
 export const http = {
   // 4xx Client Errors
-  badRequest: {
+  400: {
     httpStatus: 400,
     code: 'BAD_REQUEST',
     name: 'Bad Request Error',
@@ -118,7 +118,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  unauthorized: {
+  401: {
     httpStatus: 401,
     code: 'UNAUTHORIZED',
     name: 'Unauthorized Error',
@@ -127,7 +127,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  paymentRequired: {
+  402: {
     httpStatus: 402,
     code: 'PAYMENT_REQUIRED',
     name: 'Payment Required Error',
@@ -136,7 +136,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  forbidden: {
+  403: {
     httpStatus: 403,
     code: 'FORBIDDEN',
     name: 'Forbidden Error',
@@ -145,7 +145,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  notFound: {
+  404: {
     httpStatus: 404,
     code: 'NOT_FOUND',
     name: 'Not Found Error',
@@ -154,7 +154,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  methodNotAllowed: {
+  405: {
     httpStatus: 405,
     code: 'METHOD_NOT_ALLOWED',
     name: 'Method Not Allowed Error',
@@ -163,7 +163,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  notAcceptable: {
+  406: {
     httpStatus: 406,
     code: 'NOT_ACCEPTABLE',
     name: 'Not Acceptable Error',
@@ -172,7 +172,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  proxyAuthenticationRequired: {
+  407: {
     httpStatus: 407,
     code: 'PROXY_AUTHENTICATION_REQUIRED',
     name: 'Proxy Authentication Required Error',
@@ -181,7 +181,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  requestTimeout: {
+  408: {
     httpStatus: 408,
     code: 'REQUEST_TIMEOUT',
     name: 'Request Timeout Error',
@@ -190,7 +190,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  conflict: {
+  409: {
     httpStatus: 409,
     code: 'CONFLICT',
     name: 'Conflict Error',
@@ -199,7 +199,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  gone: {
+  410: {
     httpStatus: 410,
     code: 'GONE',
     name: 'Gone Error',
@@ -208,7 +208,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  lengthRequired: {
+  411: {
     httpStatus: 411,
     code: 'LENGTH_REQUIRED',
     name: 'Length Required Error',
@@ -217,7 +217,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  preconditionFailed: {
+  412: {
     httpStatus: 412,
     code: 'PRECONDITION_FAILED',
     name: 'Precondition Failed Error',
@@ -226,7 +226,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  payloadTooLarge: {
+  413: {
     httpStatus: 413,
     code: 'PAYLOAD_TOO_LARGE',
     name: 'Payload Too Large Error',
@@ -235,7 +235,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  uriTooLong: {
+  414: {
     httpStatus: 414,
     code: 'URI_TOO_LONG',
     name: 'URI Too Long Error',
@@ -244,7 +244,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  unsupportedMediaType: {
+  415: {
     httpStatus: 415,
     code: 'UNSUPPORTED_MEDIA_TYPE',
     name: 'Unsupported Media Type Error',
@@ -253,7 +253,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  rangeNotSatisfiable: {
+  416: {
     httpStatus: 416,
     code: 'RANGE_NOT_SATISFIABLE',
     name: 'Range Not Satisfiable Error',
@@ -262,7 +262,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  expectationFailed: {
+  417: {
     httpStatus: 417,
     code: 'EXPECTATION_FAILED',
     name: 'Expectation Failed Error',
@@ -271,7 +271,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  imATeapot: {
+  418: {
     httpStatus: 418,
     code: 'IM_A_TEAPOT',
     name: 'Im A Teapot Error',
@@ -280,7 +280,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  unprocessableEntity: {
+  422: {
     httpStatus: 422,
     code: 'UNPROCESSABLE_ENTITY',
     name: 'Unprocessable Entity Error',
@@ -289,7 +289,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  locked: {
+  423: {
     httpStatus: 423,
     code: 'LOCKED',
     name: 'Locked Error',
@@ -298,7 +298,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  failedDependency: {
+  424: {
     httpStatus: 424,
     code: 'FAILED_DEPENDENCY',
     name: 'Failed Dependency Error',
@@ -307,7 +307,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  tooEarly: {
+  425: {
     httpStatus: 425,
     code: 'TOO_EARLY',
     name: 'Too Early Error',
@@ -316,7 +316,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  upgradeRequired: {
+  426: {
     httpStatus: 426,
     code: 'UPGRADE_REQUIRED',
     name: 'Upgrade Required Error',
@@ -325,7 +325,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  preconditionRequired: {
+  428: {
     httpStatus: 428,
     code: 'PRECONDITION_REQUIRED',
     name: 'Precondition Required Error',
@@ -334,7 +334,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  tooManyRequests: {
+  429: {
     httpStatus: 429,
     code: 'TOO_MANY_REQUESTS',
     name: 'Too Many Requests Error',
@@ -343,7 +343,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  requestHeaderFieldsTooLarge: {
+  431: {
     httpStatus: 431,
     code: 'REQUEST_HEADER_FIELDS_TOO_LARGE',
     name: 'Request Header Fields Too Large Error',
@@ -352,7 +352,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  unavailableForLegalReasons: {
+  451: {
     httpStatus: 451,
     code: 'UNAVAILABLE_FOR_LEGAL_REASONS',
     name: 'Unavailable For Legal Reasons Error',
@@ -362,7 +362,7 @@ export const http = {
   } satisfies ErrorXOptions,
 
   // 5xx Server Errors
-  internalServerError: {
+  500: {
     httpStatus: 500,
     code: 'INTERNAL_SERVER_ERROR',
     name: 'Internal Server Error',
@@ -371,7 +371,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  notImplemented: {
+  501: {
     httpStatus: 501,
     code: 'NOT_IMPLEMENTED',
     name: 'Not Implemented Error',
@@ -380,7 +380,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  badGateway: {
+  502: {
     httpStatus: 502,
     code: 'BAD_GATEWAY',
     name: 'Bad Gateway Error',
@@ -389,7 +389,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  serviceUnavailable: {
+  503: {
     httpStatus: 503,
     code: 'SERVICE_UNAVAILABLE',
     name: 'Service Unavailable Error',
@@ -398,7 +398,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  gatewayTimeout: {
+  504: {
     httpStatus: 504,
     code: 'GATEWAY_TIMEOUT',
     name: 'Gateway Timeout Error',
@@ -407,7 +407,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  httpVersionNotSupported: {
+  505: {
     httpStatus: 505,
     code: 'HTTP_VERSION_NOT_SUPPORTED',
     name: 'HTTP Version Not Supported Error',
@@ -416,7 +416,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  variantAlsoNegotiates: {
+  506: {
     httpStatus: 506,
     code: 'VARIANT_ALSO_NEGOTIATES',
     name: 'Variant Also Negotiates Error',
@@ -425,7 +425,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  insufficientStorage: {
+  507: {
     httpStatus: 507,
     code: 'INSUFFICIENT_STORAGE',
     name: 'Insufficient Storage Error',
@@ -434,7 +434,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  loopDetected: {
+  508: {
     httpStatus: 508,
     code: 'LOOP_DETECTED',
     name: 'Loop Detected Error',
@@ -443,7 +443,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  notExtended: {
+  510: {
     httpStatus: 510,
     code: 'NOT_EXTENDED',
     name: 'Not Extended Error',
@@ -452,7 +452,7 @@ export const http = {
     type: 'http',
   } satisfies ErrorXOptions,
 
-  networkAuthenticationRequired: {
+  511: {
     httpStatus: 511,
     code: 'NETWORK_AUTHENTICATION_REQUIRED',
     name: 'Network Authentication Required Error',


### PR DESCRIPTION
## Summary

  Refactored HTTP error presets to use numeric status codes as keys instead of descriptive camelCase names for more intuitive API.
