### PR TITLE
Switch deploy workflow to npm trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     environment: production
     permissions:
       contents: write
-      packages: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -63,18 +64,13 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Set registry
-        run: 'echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish to NPM (dry run)
         if: ${{ inputs.dry_run }}
-        run: pnpm publish --dry-run --access public --no-git-checks
+        run: npm publish --dry-run --access public
 
       - name: Publish to NPM
         if: ${{ !inputs.dry_run }}
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish --access public --provenance
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret-based auth with OIDC trusted publishing
- Add `id-token: write` permission for provenance signing
- Switch from `pnpm publish` to `npm publish --provenance`
- Remove manual `.npmrc` token configuration step

## Setup required
After merging, configure trusted publishing on npmjs.com:
1. Go to package settings → Publishing access
2. Add trusted publisher: repo `bombillazo/error-x`, workflow `deploy.yml`, environment `production`
3. Remove the `NPM_TOKEN` secret from GitHub repo settings